### PR TITLE
Only update zoom if zoom prop changed

### DIFF
--- a/src/ImageCrop.js
+++ b/src/ImageCrop.js
@@ -108,8 +108,10 @@ class ImageCrop extends Component {
     });
   }
   componentWillReceiveProps(nextProps){
-    var zoom = (100 - nextProps.zoom)/100;
-    this.setState({ zoom: zoom })
+    if (this.props.zoom != nextProps.zoom) {
+      var zoom = (100 - nextProps.zoom)/100;
+      this.setState({ zoom: zoom });
+    }
   }
   render() {
     return (


### PR DESCRIPTION
### The issue this aims to solve
If you pinch to zoom, and then update the parent component, the zoom resets to whatever prop you initially passed into it. This can lead to an unexpected resize and repositioning of the image crop area.

### This solution
In `componentWillReceiveProps`, only update the `zoom` state if the `zoom` prop changes. 

Maybe there's a better way to do this by adding callbacks on zoom, so you can update the parent component when pinching?

