### PR TITLE
Support filePath prop to save to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ yarn add react-native-image-cropper
 - `pinchToZoom` Use pinch to zoom image? (default: true)
 - `quality`: a value from 0 to 1 to describe the quality of the snapshot. 0 means 0% (most compressed) and 1 means 100% (best quality). (default: 1)
 - `type`: the file type default value is **"png"**, **"jpg"** is also supported. Refer to implementations to see more supported values. (default: jpg)
+- `format`: the format of the output. Supported values: **"base64"**, **"file"**. (default: base64)
+- `filePath`: if format is **"file"**, the path to write the image to (default: "")
 - `pixelRatio`: the pixel ratio to use for the rendering. By default the screen pixel scale will be used.
 
 #### `{ImageCrop}` Functions

--- a/src/ImageCrop.js
+++ b/src/ImageCrop.js
@@ -191,7 +191,7 @@ class ImageCrop extends Component {
     )
   }
   crop(){
-    return this.refs.cropit.captureFrame({quality: this.props.quality, type: this.props.type, format: this.props.format})
+    return this.refs.cropit.captureFrame({quality: this.props.quality, type: this.props.type, format: this.props.format, filePath: this.props.filePath})
   }
 }
 ImageCrop.defaultProps = {

--- a/src/ImageCrop.js
+++ b/src/ImageCrop.js
@@ -205,6 +205,7 @@ ImageCrop.defaultProps = {
   pixelRatio: PixelRatio.get(),
   type: 'jpg',
   format: 'base64',
+  filePath: ''
 }
 ImageCrop.propTypes = {
   image: React.PropTypes.string.isRequired,
@@ -217,5 +218,6 @@ ImageCrop.propTypes = {
   pixelRatio: React.PropTypes.number,
   type: React.PropTypes.string,
   format: React.PropTypes.string,
+  filePath: React.PropTypes.string
 }
 module.exports=ImageCrop


### PR DESCRIPTION
This PR adds support to save the cropped image to a file with a specified URI by passing the `filePath` prop to the config.