### PR TITLE
Reset image size on source image update in ImageCrop component 

### DIFF
--- a/src/ImageCrop.js
+++ b/src/ImageCrop.js
@@ -188,13 +188,13 @@ class ImageCrop extends Component {
     return (
         <View {...this._panResponder.panHandlers}>
           <Surface width={this.props.cropWidth} height={this.props.cropHeight} pixelRatio={this.props.pixelRatio} backgroundColor="transparent" ref="cropit">
-            <GLImage
-              source={{ uri: this.props.image}}
+		        <GLImage
+		          source={{ uri: this.props.image}}
               imageSize={{height: this.state.imageHeight, width: this.state.imageWidth}}
-              resizeMode="cover"
-              zoom={this.state.zoom}
-              center={[this.state.centerX, this.state.centerY]}
-            />
+		          resizeMode="cover"
+		          zoom={this.state.zoom}
+		          center={[this.state.centerX, this.state.centerY]}
+		        />
           </Surface>
         </View>
     )

--- a/src/ImageCrop.js
+++ b/src/ImageCrop.js
@@ -157,6 +157,14 @@ class ImageCrop extends Component {
     })
   }
   componentWillReceiveProps(nextProps){
+    // Update image size on image props update
+    Image.getSize(nextProps.image, (width, height) => {
+      this.setState({
+        imageHeight: height,
+        imageWidth: width,
+      })
+    })
+
     if (this.props.zoom != nextProps.zoom) {
       var zoom = (100 - nextProps.zoom)/100
       this.setState({ zoom: zoom })
@@ -180,13 +188,13 @@ class ImageCrop extends Component {
     return (
         <View {...this._panResponder.panHandlers}>
           <Surface width={this.props.cropWidth} height={this.props.cropHeight} pixelRatio={this.props.pixelRatio} backgroundColor="transparent" ref="cropit">
-		        <GLImage
-		          source={{ uri: this.props.image}}
+            <GLImage
+              source={{ uri: this.props.image}}
               imageSize={{height: this.state.imageHeight, width: this.state.imageWidth}}
-		          resizeMode="cover"
-		          zoom={this.state.zoom}
-		          center={[this.state.centerX, this.state.centerY]}
-		        />
+              resizeMode="cover"
+              zoom={this.state.zoom}
+              center={[this.state.centerX, this.state.centerY]}
+            />
           </Surface>
         </View>
     )


### PR DESCRIPTION
Fixing issue with not reseting image size when ImageCrop prop image is changed without unmounting component. Due to the fact that component kept values of previous image, next image was displayed with not correct aspect ratio in case they are different.