### PR TITLE
Added a new property for ability to add some custom Overlay

### DIFF
--- a/src/ImageCrop.js
+++ b/src/ImageCrop.js
@@ -196,6 +196,7 @@ class ImageCrop extends Component {
 		          center={[this.state.centerX, this.state.centerY]}
 		        />
           </Surface>
+          {this.props.Overlay}
         </View>
     )
   }
@@ -214,7 +215,8 @@ ImageCrop.defaultProps = {
   pixelRatio: PixelRatio.get(),
   type: 'jpg',
   format: 'base64',
-  filePath: ''
+  filePath: '',
+  Overlay: null,
 }
 ImageCrop.propTypes = {
   image: PropTypes.string.isRequired,
@@ -227,6 +229,7 @@ ImageCrop.propTypes = {
   pixelRatio: PropTypes.number,
   type: PropTypes.string,
   format: PropTypes.string,
-  filePath: PropTypes.string
+  filePath: PropTypes.string,
+  Overlay: PropTypes.func,
 }
 module.exports=ImageCrop


### PR DESCRIPTION
How to use it now:
```
                <ImageCrop 
                    ref={'cropper'}
                    image={IMAGE_PATH}
                    cropWidth={292}
                    cropHeight={202}
                    zoom={50}
                    maxZoom={80}
                    minZoom={20}
                    panToMove={true}
                    pinchToZoom={true}
                    Overlay={(
                        <MyAwesomeOverlay />
                    )}
                />
```

Result:
![screen shot 2018-09-15 at 3 12 25 pm](https://user-images.githubusercontent.com/25571153/45586117-ce299800-b8f9-11e8-9ecc-83e9a17880e4.png)

👍 
